### PR TITLE
15 Jan 2019 updates to consortium website

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,7 +22,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: targetvalidate
 github_username:  opentargets
-linkedin: https://www.linkedin.com/company/centre-for-therapeutic-target-validation
+linkedin: https://www.linkedin.com/company/open-targets
 facebook: https://www.facebook.com/OpenTargets/
 repository: opentargets/opentargets.github.io
 

--- a/_data/geneticscore.yml
+++ b/_data/geneticscore.yml
@@ -12,8 +12,3 @@
   role: Team Member
   institute: Sanger
   email: ellen.schmidt@sanger.ac.uk
-  
-- name: Daniel Wright
-  role: Team Member
-  institute: Sanger
-  email: daniel.wright@sanger.ac.uk

--- a/_data/platformteam.yml
+++ b/_data/platformteam.yml
@@ -24,7 +24,7 @@
   github: AsierGonzalez
 
 - name: Andrew Hercules
-  role: UX lead
+  role: User Experience Lead
   institute: EMBL-EBI
   github: andrewhercules
 
@@ -34,19 +34,14 @@
   github: gkos-bio
 
 - name: Cinzia Malangone
-  role: Software developer
+  role: Backend Software Engineer
   institute: EMBL-EBI
-  github:  
+  github:  cmalangone
 
 - name: Elaine McAuley
   role: Project Manager
   institute: EMBL-EBI
   github: ElaineMcA 
-  
-- name: Cinzia Malangone
-  role: Software Developer
-  institute: EMBL-EBI
-  github:  
   
 - name: Alfredo Miranda
   role: Frontend developer
@@ -57,6 +52,11 @@
   role: Frontend developer
   institute: EMBL-EBI
   github: peatroot
+
+- name: Eirini Petsalaki
+  role: Bioinformatician
+  institute: EMBL-EBI
+  github: EPetsalaki
 
 - name: Michaela Spitzer
   role: Bioinformatician

--- a/contact.md
+++ b/contact.md
@@ -22,18 +22,18 @@ permalink: /contact/
     <li><a href="https://github.com/opentargets"><span class="fa fa-github"></span> <span class="hidden-xs">GitHub</span></a></li>
 </ul>
 
-## Press releases
-To learn more about the Open Targets or to arrange an interview with one of the scientists, please contact the press team. Your email will reach press officers at Biogen, EMBL-EBI, GSK, Takeda and the Wellcome Trust Sanger Institute.
-
-E-mail.: [press@opentargets.org](mailto:press@opentargets.org)
-
-Tel.: +44 (0)1223 494 665
-
 ## Scientific leadership
 For information about how your company might interact with Open Targets, email [{{ site.email }}](email). Your message will be sent to the scientific coordinators.
 
+## Press releases
+To learn more about the Open Targets or to arrange an interview with one of the scientists, please contact the press team. Your email will reach press officers at Biogen, Celgene, EMBL-EBI, GSK, Sanofi, Takeda, and the Wellcome Sanger Institute.
+
+E-mail.: [press@opentargets.org](mailto:press@opentargets.org)
+
+Tel.: + 44 (0)1223 494 369
+
 ## Help us improve the Open Targets Platform!
-The [Open Targets Platform](https://www.targetvalidation.org) aims to support researchers in identifying early drug targets faster and with more confidence. The platform integrates data from several public databases and is the result of a collaboration between the Sanger Institute, GlaxoSmithKline (GSK), the European Bioinformatics Institute (EMBL-EBI), Biogen and Takeda.
+The [Open Targets Platform](https://www.targetvalidation.org) aims to support researchers in identifying early drug targets faster and with more confidence. The platform integrates data from several public databases and is the result of a collaboration between Biogen, Celgene, EMBL-EBI, GSK, Sanofi, Takeda, and the Wellcome Sanger Institute.
 
 As part of our ongoing efforts to improve this valuable public resource, we want to talk to experimental biology researchers who study associations of human genes with diseases. We are interested in understanding how well the platform meets your needs and what other information and features would make it more useful to you. A typical session takes about an hour of your time. Previous participants have found them to be a lot of fun!
 

--- a/contact.md
+++ b/contact.md
@@ -17,9 +17,9 @@ permalink: /contact/
 
 <ul class="footer-social-list">
     <li><a href="{{ site.linkedin }}"><span class="fa fa-linkedin"></span> <span class="hidden-xs">Linkedin</span></a></li>
-    <li><a href="http://twitter.com/targetvalidate"><span class="fa fa-twitter"></span> <span class="hidden-xs">Twitter</span></a></li>
+    <li><a href="http://twitter.com/{{site.twitter_username}}"><span class="fa fa-twitter"></span> <span class="hidden-xs">Twitter</span></a></li>
     <li><a href="{{ site.facebook }}"><span class="fa fa-facebook"></span> <span class="hidden-xs">Facebook</span></a></li>
-    <li><a href="https://github.com/opentargets"><span class="fa fa-github"></span> <span class="hidden-xs">GitHub</span></a></li>
+    <li><a href="https://github.com/{{site.github_username}}"><span class="fa fa-github"></span> <span class="hidden-xs">GitHub</span></a></li>
 </ul>
 
 ## Scientific leadership

--- a/jobs.md
+++ b/jobs.md
@@ -8,11 +8,12 @@ Please note that some applications will be reviewed on an ongoing basis and the 
 
 #### [Advanced Research Assistant - Experimental Cancer Genetics](https://jobs.sanger.ac.uk/wd/plsql/wd_portal.show_job?p_web_site_id=1764&p_web_page_id=373804)
 *A Wellcome Sanger Institute contract*
-Closing date: 20 January 2019
 
 A new project funded by Open Targets, joint between the Experimental Cancer Genetics group headed by Dr David Adams at the Wellcome Sanger Institute together with Open Targets partners, is to perform in depth analysis of factors that control T cell survival and differentiation within the tumour microenvironment. This will involve the use of bespoke targeted CRISPR screens applied to primary cells and using in vivo tumour models in order to identify novel candidate genes and/or pathways for validation and in-depth characterization.
 
 We are looking for an enthusiastic individual to contribute to the generation of this data including cell culture and performing in vivo tumour models. Detailed record keeping is required, as is contribution to data analysis, review and reporting.
+
+__Closing date: 20 January 2019__
 
 [More details at the Wellcome Sanger Institute website](https://jobs.sanger.ac.uk/wd/plsql/wd_portal.show_job?p_web_site_id=1764&p_web_page_id=373804)
 
@@ -20,7 +21,6 @@ We are looking for an enthusiastic individual to contribute to the generation of
 
 #### [Open Targets Senior Administrator - Open Targets Core Team](https://www.embl.de/jobs/searchjobs/index.php?ref=EBI01335)
 *An EMBL-EBI contract*
-Closing date: 25 January 2019
 
 We are looking for a Senior Administrator to provide high-level administrative support to the Open Targets Executive Team and members of the Open Targets team.
 
@@ -30,6 +30,8 @@ The post holder will organise several scientific and non-scientific meetings and
 
 The position is based in dedicated Open Targets space within EMBL-EBI and reports to the Open Targets Operations Director and the Open Targets Scientific Director.
 
+__Closing date: 25 January 2019__
+
 [More details at the EMBL-EBI website](https://www.embl.de/jobs/searchjobs/index.php?ref=EBI01335)
 
 
@@ -37,7 +39,6 @@ The position is based in dedicated Open Targets space within EMBL-EBI and report
 
 #### [Open Targets Platform Coordinator - Open Targets Core Team](https://www.embl.de/jobs/searchjobs/index.php?ref=EBI01323)
 *An EMBL-EBI contract*
-Closing date: 31 January 2019
 
 We are looking for an experienced bioinformatician, computer scientist or drug discovery scientist to provide leadership for the core Open Targets Platform project involved in large-scale biological data analysis and integration for drug target identification and prioritisation.
 
@@ -47,13 +48,14 @@ Responsibilities will involve setting the scientific strategy for the OT Platfor
 
 The post represents an excellent opportunity to lead the development of the core data integration within Open Targets and to be involved in a rapidly evolving field.
 
+__Closing date: 31 January 2019__
+
 [More details at the EMBL-EBI website](https://www.embl.de/jobs/searchjobs/index.php?ref=EBI01323)
 
 ***
 
 #### [Statistical Geneticist](https://jobs.sanger.ac.uk/wd/plsql/wd_portal.show_job?p_web_site_id=1764&p_web_page_id=371402)
 *A Wellcome Sanger Institute contract*
-Closing date: 28 February 2019
 
 A Statistical Geneticist role funded by Open Targets, is available at the Wellcome Sanger Institute in a new team under the leadership of Dr. Maya Ghoussaini. This is an exciting opportunity for you to participate in the enhancement of the existing [Open Targets Genetics Portal](https://genetics.opentargets.org/) through the development of new functionality and features.
 
@@ -67,5 +69,7 @@ You will have the opportunity to work across a range of analysis such as:
 * Work with existing members of the team to integrate genetic and cell-specific genomic data to identify and validate causal links between targets and diseases and improve the Genetics Portal.
 
 We welcome candidates with a background in statistical genetics or relevant discipline with advanced level of programming skills suitable for statistical genetic analyses of complex diseases. Experience in functional genomics data analysis is highly desirable. You will have the opportunity to interact with active computational and experimental research teams using cutting edge genomic techniques. 
+
+__Closing date: 28 February 2019__
 
 [More details at the Wellcome Sanger Institute website](https://jobs.sanger.ac.uk/wd/plsql/wd_portal.show_job?p_web_site_id=1764&p_web_page_id=371402)

--- a/jobs.md
+++ b/jobs.md
@@ -6,6 +6,16 @@ permalink: /jobs/
 Please note that some applications will be reviewed on an ongoing basis and the advertised post(s) may be filled before the stated deadline. 
 
 
+#### [Advanced Research Assistant - Experimental Cancer Genetics](https://jobs.sanger.ac.uk/wd/plsql/wd_portal.show_job?p_web_site_id=1764&p_web_page_id=373804)
+*A Wellcome Sanger Institute contract*
+Closing date: 20 January 2019
+
+A new project funded by Open Targets, joint between the Experimental Cancer Genetics group headed by Dr David Adams at the Wellcome Sanger Institute together with Open Targets partners, is to perform in depth analysis of factors that control T cell survival and differentiation within the tumour microenvironment. This will involve the use of bespoke targeted CRISPR screens applied to primary cells and using in vivo tumour models in order to identify novel candidate genes and/or pathways for validation and in-depth characterization.
+
+We are looking for an enthusiastic individual to contribute to the generation of this data including cell culture and performing in vivo tumour models. Detailed record keeping is required, as is contribution to data analysis, review and reporting.
+
+[More details at the Wellcome Sanger Institute website](https://jobs.sanger.ac.uk/wd/plsql/wd_portal.show_job?p_web_site_id=1764&p_web_page_id=373804)
+
 ***
 
 #### [Open Targets Senior Administrator - Open Targets Core Team](https://www.embl.de/jobs/searchjobs/index.php?ref=EBI01335)
@@ -38,3 +48,24 @@ Responsibilities will involve setting the scientific strategy for the OT Platfor
 The post represents an excellent opportunity to lead the development of the core data integration within Open Targets and to be involved in a rapidly evolving field.
 
 [More details at the EMBL-EBI website](https://www.embl.de/jobs/searchjobs/index.php?ref=EBI01323)
+
+***
+
+#### [Statistical Geneticist](https://jobs.sanger.ac.uk/wd/plsql/wd_portal.show_job?p_web_site_id=1764&p_web_page_id=371402)
+*A Wellcome Sanger Institute contract*
+Closing date: 28 February 2019
+
+A Statistical Geneticist role funded by Open Targets, is available at the Wellcome Sanger Institute in a new team under the leadership of Dr. Maya Ghoussaini. This is an exciting opportunity for you to participate in the enhancement of the existing [Open Targets Genetics Portal](https://genetics.opentargets.org/) through the development of new functionality and features.
+
+You will actively engage in the integration of new eQTL datasets and tissue-specific chromatin interaction datasets.
+
+You will have the opportunity to work across a range of analysis such as:
+
+* Aggregate large scale GWAS data from multiple consortia and across a wide range of disease and traits.
+* Perform association analysis on UK Biobank data with a particular focus on therapeutic areas important for Open Targets
+* Work together with other members of the Open Targets team on statistical genetics analysis for large scale sequence analysis
+* Work with existing members of the team to integrate genetic and cell-specific genomic data to identify and validate causal links between targets and diseases and improve the Genetics Portal.
+
+We welcome candidates with a background in statistical genetics or relevant discipline with advanced level of programming skills suitable for statistical genetic analyses of complex diseases. Experience in functional genomics data analysis is highly desirable. You will have the opportunity to interact with active computational and experimental research teams using cutting edge genomic techniques. 
+
+[More details at the Wellcome Sanger Institute website](https://jobs.sanger.ac.uk/wd/plsql/wd_portal.show_job?p_web_site_id=1764&p_web_page_id=371402)


### PR DESCRIPTION
Update to [Open Targets consortium website](https://www.opentargets.org/):

**Contact Page**
- Updated the phone number to number of EBI's Communications Officer
- Moved the Press Releases section underneath the Scientific Leadership section
- Changed “Wellcome Trust Sanger Institute” to “Wellcome Sanger Institute”
- Updated social media links

**People Page**
- Updated staff listing based on new starters and recent departures

**Jobs Page**
- Added Statistical Geneticist role
- Added Advanced Research Assistant role