### PR TITLE
Adding registration and code of conduct

### DIFF
--- a/pages/hackathon.html
+++ b/pages/hackathon.html
@@ -25,14 +25,11 @@ title: Hackathon
           The Open Targets Platform turns 10 this year! Join us in person or
           online for a two-day hackathon connecting scientists, developers, and
           the bioinformatics community to explore data, analyses and tools for
-          target discovery. Registrations will open in June.
+          target discovery.
         </p>
         <div class="d-flex flex-wrap">
-          <!--
           <a href="#registration" class="btn btn-primary mr-3 mb-2"
-            >Register Now</a
-          >
-           -->
+            >Register Now</a>
           <a href="#projects" class="btn btn-outline-primary mb-2"
             >Submit Project</a
           >
@@ -189,7 +186,8 @@ title: Hackathon
       </div>
     </div>
   </div>
-</section>
+  </section>
+
 
 <!-- Timeline Section -->
 <section id="timeline">
@@ -309,7 +307,6 @@ title: Hackathon
     <div class="row justify-content-center mb-5">
       <div class="col-lg-8 text-center">
         <h2 class="section-heading">Registration</h2>
-        <p class="lead">Registrations will open on 30 June</p>
       </div>
     </div>
 
@@ -412,10 +409,10 @@ title: Hackathon
                   <p>
                     <strong>Travel and accommodation:</strong> Participants are
                     responsible for organising and funding their travel and
-                    accommodation expenses.
+                    accommodation expenses.We are hoping to organise a travel fund for students.
                   </p>
-                  <!-- <a href="#" class="btn btn-primary mt-3 d-block"
-                    >Register for In-Person</a>-->
+                  <a href="https://docs.google.com/forms/d/e/1FAIpQLSfBbzgnnFUp9Yd-nWgpFOF3leE2bSgjZWGE3m4Q29P8C9Q45A/viewform?usp=pp_url&entry.672687580=In+person" class="btn btn-primary mt-3 d-block"
+                    >Register for In-Person</a>
                 </div>
               </div>
             </div>
@@ -478,8 +475,8 @@ title: Hackathon
                     to accommodate multiple time zones when possible. All
                     sessions will be recorded for asynchronous viewing.
                   </p>
-                  <!-- <a href="#" class="btn btn-primary mt-3 d-block"
-                    >Register for Virtual</a> -->
+                  <a href="https://docs.google.com/forms/d/e/1FAIpQLSfBbzgnnFUp9Yd-nWgpFOF3leE2bSgjZWGE3m4Q29P8C9Q45A/viewform?usp=pp_url&entry.672687580=Online" class="btn btn-primary mt-3 d-block"
+                    >Register for Virtual</a>
                 </div>
               </div>
             </div>
@@ -489,6 +486,102 @@ title: Hackathon
     </div>
   </div>
 </section>
+
+<!-- Code of conduct Section -->
+<section id="code-of-conduct">
+  <div class="container">
+    <div class="row justify-content-center mb-5">
+      <div class="col-lg-8 text-center">
+        <h2 class="section-heading">Hackathon Code of Conduct</h2>
+        <p class="lead">
+          All participants must agree to abide by the code of conduct.
+        </p>
+      </div>
+    </div>
+
+<div class="row my-4">
+      <div class="col-lg-10 mx-auto">
+        <div class="accordion faq-accordion" id="cocAccordion">
+          <div class="card">
+            <div class="card-header">
+              <h5 class="mb-0">
+                <button
+                  class="btn btn-link collapsed"
+                  type="button"
+                  data-toggle="collapse"
+                  data-target="#collapse{{ forloop.index }}"
+                  aria-expanded="false"
+                  aria-controls="collapse{{ forloop.index }}">
+                Code of conduct
+                </button>
+              </h5>
+            </div>
+            <div
+              id="collapse{{ forloop.index }}"
+              class="collapse"
+              aria-labelledby="heading{{ forloop.index }}"
+              data-parent="#cocAccordion">
+              <div class="card-body">
+                <p>All event attendees (whether participating online or in person) are expected to abide by this Code of Conduct. We aim to ensure that no individual or groups feel harassed or uncomfortable participating in the event or at social activities, in-person or online. We ask all members of our community to help maintain supportive and productive workspaces and to avoid behaviours that can make individuals feel unsafe or unwelcome.</p>
+                <p>Questions, concerns, or ideas on what we can include? Get in touch at <a href="mailto:outreach@opentargets.org">outreach@opentargets.org</a>.</p>
+                <br/>
+                <h5>Ethos</h5>
+                <p>We support the dissemination of knowledge in an open and respectful environment. We promote diversity and equality and do not discriminate on gender, race, age, religion, physical appearance, disability, sexual orientation or any other information provided.</p>
+                <p>We aim to provide a friendly, safe and welcoming environment for all participants. Therefore, we ask that attendees treat all speakers and participants with respect, courtesy, and professionalism.</p>
+                <br/>
+                <h5>Code of Conduct</h5>
+                <p>Be aware that certain language and images can offend groups and cultures different to your own. If you have any doubt about whether specific language or images in your presentations could be misinterpreted, remove them.</p>
+                <p>We will not tolerate harassment or intimidation of any person, whether verbal, physical, or written (including on our networking channels, social media, or by email).</p>
+                <p>Harassment includes, but is not limited to:</p>
+                <ul>
+                  <li>Offensive or unwanted comments on gender, race, age, religion, physical appearance, disability, sexual orientation.</li>
+                  <li>Use of sexual images, inappropriate physical contact, unwelcome sexual attention or stalking.</li>
+                  <li>Sustained interruption of speakers or those asking questions.</li>
+                  <li>Unwanted photography or filming. Make you sure ask permission before taking photos of a group and taking screenshots of individuals during video calls, especially if you plan to post them online.</li>
+                </ul>
+                <p>Intimidation includes, but is not limited to:</p>
+                <ul>
+                  <li>Making threats</li>
+                  <li>Bullying</li>
+                  <li>Personal attacks</li>
+                </ul>
+                <p>Behaviour that results in damage to Campus property is not acceptable and you will be expected to pay for repair/replacement/cleaning.</p>
+                <br/>
+                <h5>Reporting an incident</h5>
+                <p>If someone makes you feel uncomfortable through their behaviours or actions, report it as soon as possible.</p>
+                <p>You can reach out to members of the hackathon organisation committee (Annalisa Buniello, Carlos Cruz, Helena Cornu, and Szymon Szykowski) directly, or contact a member of the Open Targets team.</p>
+                <p>Issues directly concerning members of the committee will be dealt with by other members of the core team — possible conflicts of interest will be taken into account.</p>
+                <p>All reports will be handled with the utmost discretion and confidentiality.</p>
+                <p>You can also report any violations to administrator [at] opentargets [dot] org. In your email report, please do your best to include:</p>
+                <ul>
+                  <li>Your contact information</li>
+                  <li>Identifying information (e.g. names, nicknames, pseudonyms) of the participant who has violated the Code of Conduct</li>
+                  <li>The behaviour that was in violation and the circumstances surrounding the incident</li>
+                  <li>The approximate time of the behaviour (if different than the time the report was made)</li>
+                  <li>Other people involved in the incident, if applicable</li>
+                  <li>If you believe the incident is ongoing</li>
+                  <li>If there is a publicly available record (e.g. mailing list record, a screenshot)</li>
+                  <li>Any additional information</li>
+                  <li>After you file a report, one or more members of our team will contact you to follow up on your report</li>
+                </ul>
+                <br/>
+                <p>The organisers reserve the right to remove, edit, or reject comments, commits, code, and other contributions that are not aligned to this code of conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.</p>
+                <p>We also reserve the right to ask any individual to leave the event (whether in-person, on campus or virtual) if they break the Code of Conduct. They will not be given a refund of any fees, and will not be allowed to reside on Campus (if they have Campus accommodation) and will not have access to the virtual platform for the remainder of the event.</p>
+                <br/>
+                <h5>Attribution and acknowledgements</h5>
+                <ul>
+                  <li><a href="https://nf-co.re/code_of_conduct">nf-code code of conduct</a></li>
+                  <li><a href="https://coursesandconferences.wellcomeconnectingscience.org/policies/">Wellcome Connecting Science code of conduct</a></li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  </section>
+
 
 <!-- Schedule Section -->
 <!-- 
@@ -811,11 +904,12 @@ title: Hackathon
     </div>
 
     <div class="row">
-      <div class="col-lg-6 mb-5 mb-lg-0">
+      <!-- <div class="col-lg-6 mb-5 mb-lg-0"> -->
+      <div class="col-lg-5 mx-auto">  <!--Temporary while we fix the contact form -->
         <div class="card h-100">
           <div class="card-body">
             <h4 class="mb-4">Contact Information</h4>
-            <p class="mb-4">
+             <p class="mb-4">
               Our team is available to answer any questions about the hackathon,
               Open Targets Platform, or how you can get involved.
             </p>
@@ -902,7 +996,7 @@ title: Hackathon
         </div>
       </div>
 
-      <div class="col-lg-6">
+      <!-- <div class="col-lg-6">
         <div class="card h-100">
           <div class="card-body">
             <h4 class="mb-4">Send Us a Message</h4>
@@ -954,8 +1048,8 @@ title: Hackathon
               </button>
             </form>
           </div>
-        </div>
-      </div>
+        </div> 
+      </div> -->
     </div>
   </div>
 </section>


### PR DESCRIPTION
- Added a button at the top linking to the registration section
- Added the registration form links to the registration section (separate links pre-filled depending on whether the user clicks from in-person registration button or online registration button)
- Added code of conduct as its own section, with an FAQ-style drawer to read the text
- Commented out the contact form until it is fixed